### PR TITLE
HttpStatusExtentionのデータ取得方法を改善

### DIFF
--- a/HttpStatusExtention/HttpStatusExtentionController.cs
+++ b/HttpStatusExtention/HttpStatusExtentionController.cs
@@ -138,7 +138,7 @@ namespace HttpStatusExtention
             if (beatmap == null) {
                 return;
             }
-            var songData = Collections.RetrieveExtraSongData(SongCore.Utilities.Hashing.GetCustomLevelHash(beatmap));
+            var songData = Collections.GetCustomLevelSongData(beatmap.levelID);
             var diffData = songData._difficulties?.FirstOrDefault(x => x._beatmapCharacteristicName == beatDataCharacteristics.GetDescription() && x._difficulty == diff);
             var currentDiffLabel = diffData?._difficultyLabel;
             if (string.IsNullOrEmpty(currentDiffLabel)) {

--- a/HttpStatusExtention/manifest.json
+++ b/HttpStatusExtention/manifest.json
@@ -3,14 +3,14 @@
   "id": "HttpStatusExtention",
   "name": "HttpStatusExtention",
   "author": "denpadokei",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "description": "",
-  "gameVersion": "1.39.0",
+  "gameVersion": "1.40.8",
   "dependsOn": {
-    "BSIPA": "^4.3.5",
-    "SongDetailsCache": "^1.2.2",
-    "SiraUtil": "^3.1.12",
-    "SongCore": "^3.14.15",
-    "HttpSiraStatus": "^13.0.0"
+    "BSIPA": "^4.3.6",
+    "SongDetailsCache": "^1.4.0",
+    "SiraUtil": "^3.2.1",
+    "SongCore": "^3.15.3",
+    "HttpSiraStatus": "^14.0.0"
   }
 }


### PR DESCRIPTION
`HttpStatusExtentionController.cs`の`SetCustomLabel`メソッドで、曲データの取得方法を`Collections.GetCustomLevelSongData`に変更し、`beatmap.levelID`を引数として使用するようにしました。これにより、データ取得の効率が向上する可能性があります。

`manifest.json`では、バージョンを`10.0.0`から`11.0.0`に更新し、ゲームバージョンを`1.39.0`から`1.40.8`に変更しました。また、依存ライブラリのバージョンも最新のものに更新されています。